### PR TITLE
Fixes for certain zkill json result conditions

### DIFF
--- a/evecharsearch/__main__.py
+++ b/evecharsearch/__main__.py
@@ -5,7 +5,7 @@ from lookup_controller import LookupController
 
 
 @click.command()
-@click.option("--name", default="Sapporo Jones", help="Name of character to search.")
+@click.option("--name", default="Baldur Kilgannon", help="Name of character to search.")
 def main(name):
     """A CLI app to find public information about an EVE Online character"""
     LookupController(name)

--- a/evecharsearch/__main__.py
+++ b/evecharsearch/__main__.py
@@ -5,7 +5,7 @@ from lookup_controller import LookupController
 
 
 @click.command()
-@click.option("--name", default="Baldur Kilgannon", help="Name of character to search.")
+@click.option("--name", default="Sapporo Jones", help="Name of character to search.")
 def main(name):
     """A CLI app to find public information about an EVE Online character"""
     LookupController(name)

--- a/evecharsearch/killmail_resolver.py
+++ b/evecharsearch/killmail_resolver.py
@@ -56,9 +56,16 @@ class KillmailResolver:
                         self.oppo_ship = self.kill_json["victim"]["ship_type_id"]
                     else:
                         pass
+        # The below KeyError is the likely result of the kill showing a weapon type instead of a ship
         except KeyError:
-            self.pla_ship = 25
-            self.oppo_ship = 29148
+            for attacker in self.kill_json["attackers"]:
+                # skip character_id checks on npc participants
+                if len(attacker) == 5:
+                    pass
+                else:
+                    if attacker["character_id"] == self.c:
+                        self.pla_ship = attacker["weapon_type_id"]
+                        self.oppo_ship = self.kill_json["victim"]["ship_type_id"]
 
         self.loc_id = self.kill_json["solar_system_id"]
 

--- a/evecharsearch/killmail_resolver.py
+++ b/evecharsearch/killmail_resolver.py
@@ -59,7 +59,7 @@ class KillmailResolver:
         # The below KeyError is the likely result of the kill showing a weapon type instead of a ship
         except KeyError:
             for attacker in self.kill_json["attackers"]:
-                # skip character_id checks on npc participants
+                # skip character_id checks on npc participants which have a block length of 5
                 if len(attacker) == 5:
                     pass
                 else:


### PR DESCRIPTION
-Fixed a condition where if an NPC entrant was on the kill an error would be raised because NPCs lack character IDs
-Added a more complete explanation of workarounds to various zkill json workarounds
-Reverted a change to the default search name while testing for bugs